### PR TITLE
Add API data to product card

### DIFF
--- a/client/src/relatedProducts/Carousel.jsx
+++ b/client/src/relatedProducts/Carousel.jsx
@@ -1,26 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
 import StyledSlide from './Slide.jsx';
+import PropTypes from 'prop-types';
 
 
 
 const Container = styled.div`
-width: 50%;
+  width: 80%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
 `;
 
-const Carousel = () => {
+const Carousel = ({ data }) => {
+  if (!data) {
+    return <div></div>;
+  }
   return (
     <Container>
-      <StyledSlide> </StyledSlide>
-      <StyledSlide> </StyledSlide>
-      <StyledSlide> </StyledSlide>
-      <StyledSlide> </StyledSlide>
+      {Object.values(data).map((product) => {
+        return <StyledSlide data={product} key={product.id}></StyledSlide>;
+      })}
     </Container>
   );
+};
+
+Carousel.propTypes = {
+  data: PropTypes.object.isRequired
 };
 
 export default Carousel;

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import Carousel from './Carousel.jsx';
+import axios from 'axios';
 
-
-const RelatedProductsWrapper = () => {
+const RelatedProductsWrapper = (props) => {
+    //get list of related products using productId prop
+    getRelatedProducts() {
+      axios.get(`/api/products/${/*prodid*/}/related`, {
+      params: {
+        product_id: props.product_id,
+      }
+    })
+    }
   return (
     <div>
       <h4>Related Products</h4>
@@ -12,6 +20,7 @@ const RelatedProductsWrapper = () => {
     </div>
   );
 };
+
 
 
 export default RelatedProductsWrapper;

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -1,26 +1,74 @@
 import React from 'react';
 import Carousel from './Carousel.jsx';
 import axios from 'axios';
+import PropTypes from 'prop-types';
 
-const RelatedProductsWrapper = (props) => {
-    //get list of related products using productId prop
-    getRelatedProducts() {
-      axios.get(`/api/products/${/*prodid*/}/related`, {
+class RelatedProductsWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      relatedProductsData: {},
+      isLoading: true
+    };
+  }
+
+  //get list of related products using productId prop
+  getRelatedProducts() {
+    axios.get('/api/products/19089/related', {
       params: {
-        product_id: props.product_id,
+        product_id: 19089
       }
-    })
+    }).then(({data}) => {
+      return Promise.all(data.map((id) => {
+        return this.getProductData(id);
+      }));
+    }).then(() => {
+      this.setState({
+        isLoading: false
+      });
+    }).catch((err) => {
+      console.log(err);
+    });
+  }
+
+  //get data for an individual product
+  //to be added to product card
+  getProductData(id) {
+    return axios.get(`/api/products/${id}`, {
+      params: {
+        product_id: id
+      }
+    }).then(({data}) => {
+      var oldProductData = this.state.relatedProductsData;
+      oldProductData[data.id] = data;
+      this.setState({
+        relatedProductsData: oldProductData
+      });
+    });
+  }
+
+  componentDidMount() {
+    this.getRelatedProducts();
+  }
+
+  render() {
+    if (this.state.isLoading) {
+      console.log('loading');
+      return <div>RELATED LOADING</div>;
     }
-  return (
-    <div>
-      <h4>Related Products</h4>
-      <Carousel/>
-      <h4>Your outfit</h4>
-      <Carousel />
-    </div>
-  );
+    return (
+      <div>
+        <h4>Related Products</h4>
+        <Carousel data={this.state.relatedProductsData}/>
+        <h4>Your outfit</h4>
+        <Carousel />
+      </div>
+    );
+  }
+}
+
+RelatedProductsWrapper.propTypes = {
+  product_id: PropTypes.number
 };
-
-
 
 export default RelatedProductsWrapper;

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -12,14 +12,15 @@ class Slide extends Component {
   render() {
     return (
       <div className={this.props.className}>
-        <StyledSlideInfo></StyledSlideInfo>
+        <StyledSlideInfo data={this.props.data}></StyledSlideInfo>
       </div>
     );
   }
 }
 
 Slide.propTypes = {
-  className: PropTypes.string.isRequired
+  className: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired
 };
 
 const StyledSlide = styled(Slide)`

--- a/client/src/relatedProducts/SlideInfo.jsx
+++ b/client/src/relatedProducts/SlideInfo.jsx
@@ -6,21 +6,22 @@ import PropTypes from 'prop-types';
 const SlideInfo = (props) => {
   return (
     <div className={props.className}>
-      <div> category </div>
-      <div> name </div>
-      <div> price </div>
-      <div> stars </div>
+      <div> {props.data.category} </div>
+      <div> {props.data.name} </div>
+      <div> {props.data.default_price} </div>
+      <div> Rating </div>
     </div>
   );
 };
 
 SlideInfo.propTypes = {
-  className: PropTypes.string.isRequired
+  className: PropTypes.string.isRequired,
+  data: PropTypes.object.isRequired
 };
 
 const StyledSlideInfo = styled(SlideInfo)`
   width: 150px;
-  height: 80px;
+  height: 100px;
   background-color: lightblue;
 `;
 


### PR DESCRIPTION
This pull request corresponds to [this ticket](https://trello.com/c/NoWrprKF) and it..
- Fetches the products related to the current product (passed in by App)
- Renders a product card for each related product
- Displays the relevant data for each respective product card

It does not fetch review data or display the product's star rating (coming soon)