### PR TITLE
add exceptions for API result property names

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
     'jest'
   ],
   'rules': {
-    'camelcase': ['error', { 'allow': ['product_id']} ],
+    'camelcase': ['error', { 'allow': ['product_id', 'default_price', 'created_at', 'updated_at', 'style_id', 'sale_price', 'original_price', 'thumbnail_url', 'review_id', 'reviewer_name', 'question_id', 'question_body', 'question_date', 'asker_name', 'question_helpfulness', 'answerer_name', 'sku_id']} ],
     'jest/no-focused-tests': 'error',
     'jest/no-identical-title': 'error',
     'jest/prefer-to-have-length': 'warn',


### PR DESCRIPTION
The current eslint rules do not allow us to require the existence of properties with underscores in them, which prevents us from requiring a prop object have the structure of an API result (the API results use underscores in many property names).
This references ticket #113.