### PR TITLE
Bug: missing modal window

### DIFF
--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -24,12 +24,12 @@ CarouselWrapper.propTypes = {
 };
 
 const Container = styled.div`
-  border: 1px solid black;
   width: 80%;
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  position: relative;
 `;
 
 export default CarouselWrapper;

--- a/client/src/relatedProducts/Modal.jsx
+++ b/client/src/relatedProducts/Modal.jsx
@@ -21,13 +21,15 @@ Modal.propTypes = {
   className: PropTypes.string.isRequired,
   handleClose: PropTypes.func.isRequired,
   show: PropTypes.bool.isRequired,
-  children: PropTypes.object
+  children: PropTypes.object,
+  data: PropTypes.object.isRequired
 };
 
 
 const StyledModal = styled(Modal)`
   display: ${props => props.show ? 'block' : 'none'};
-  position: fixed;
+  position: absolute;
+  z-index: 1;
   width: 30%;
   height: auto;
   top: 50%;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -6,7 +6,6 @@ import StyledSlide from './Slide.jsx';
 class OutfitCarousel extends React.Component {
   constructor(props) {
     super(props);
-
     this.cardButtonClick = this.cardButtonClick.bind(this);
   }
 

--- a/client/src/relatedProducts/RelatedCarousel.jsx
+++ b/client/src/relatedProducts/RelatedCarousel.jsx
@@ -12,8 +12,9 @@ class RelatedCarousel extends React.Component {
     this.state = {
       showModal: false
     };
-    this.show = this.showModal.bind(this);
+    this.showModal = this.showModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
+    this.cardButtonClick = this.cardButtonClick.bind(this);
   }
 
   showModal() {

--- a/client/src/relatedProducts/RelatedCarousel.jsx
+++ b/client/src/relatedProducts/RelatedCarousel.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import StyledSlide from './Slide.jsx';
 import StyledModal from './Modal.jsx';
+import styled from 'styled-components';
 
 
 class RelatedCarousel extends React.Component {
@@ -13,7 +14,6 @@ class RelatedCarousel extends React.Component {
     };
     this.show = this.showModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
-    this.cardButtonClick = this.cardButtonClick.bind(this);
   }
 
   showModal() {
@@ -38,10 +38,11 @@ class RelatedCarousel extends React.Component {
       <>
         {Object.values(this.props.data).map((product) => {
           return <StyledSlide data={product}
+            value={product}
             cardButtonClick={this.cardButtonClick}
             key={product.id}
             render={onClick => (
-              <button onClick={onClick}>x</button>
+              <Button onClick={onClick}>★</Button>
             )}>
           </StyledSlide>;
         })}
@@ -54,6 +55,18 @@ class RelatedCarousel extends React.Component {
     );
   }
 }
+
+const Button = styled.button `
+  font-size: 1em;
+  color: white;
+  background: none;
+  border-radius: 3px;
+  border: none;
+  width: 25%;
+  position: absolute;
+  top: 0%;
+  left: 80%;
+`;
 
 RelatedCarousel.propTypes = {
   data: PropTypes.object.isRequired

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -34,6 +34,7 @@ const StyledSlide = styled(Slide)`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  position: relative;
 `;
 
 export default StyledSlide;

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -6,15 +6,19 @@ import PropTypes from 'prop-types';
 class Slide extends Component {
   constructor(props) {
     super(props);
+    this.handleButtonClick = this.handleButtonClick.bind(this);
   }
 
+  handleButtonClick(event) {
+    event.preventDefault();
+    this.props.cardButtonClick();
+  }
 
   render() {
     return (
       <div className={this.props.className}>
-        {this.props.render(this.props.cardButtonClick)}
+        {this.props.render(this.handleButtonClick)}
         <StyledSlideInfo data={this.props.data}></StyledSlideInfo>
-
       </div>
     );
   }


### PR DESCRIPTION
This PR refers to [this ticket](https://trello.com/c/VluOIrwT) 
It fixes a bug where the modal window was not popping up when a star button is clicked.

There's also some minor styling changes thrown in by accident: 
(pushed to the wrong branch, my bad)
It centers the modal window and removes borders around the soon-to-be carousels