### PR TITLE
Add product from app state to outfit

### DIFF
--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -30,6 +30,7 @@ const Container = styled.div`
   align-items: center;
   justify-content: space-between;
   position: relative;
+  padding: 10px;
 `;
 
 export default CarouselWrapper;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -51,7 +51,7 @@ class OutfitCarousel extends React.Component {
     event.preventDefault();
     //get product data from app
     //pass to addToOutfit as parameter
-    this.addToOutfit(fakeProduct);
+    this.addToOutfit(this.props.currentProduct);
   }
 
   render() {
@@ -77,7 +77,8 @@ class OutfitCarousel extends React.Component {
 }
 
 OutfitCarousel.propTypes = {
-  data: PropTypes.object.isRequired
+  data: PropTypes.object.isRequired,
+  currentProduct: PropTypes.object
 };
 
 const FirstSlide = styled.div`

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import StyledSlide from './Slide.jsx';
 import styled from 'styled-components';
 
-let fakeProduct = {'id': 19090, 'campus': 'hr-rfe', 'name': 'Bright Future Sunglasses', 'slogan': 'You\'ve got to wear shades', 'description': 'Where you\'re going you might not need roads, but you definitely need some shades. Give those baby blues a rest and let the future shine bright on these timeless lenses.', 'category': 'Accessories', 'default_price': '69.00', 'created_at': '2021-02-23T19:24:34.450Z', 'updated_at': '2021-02-23T19:24:34.450Z', 'features': [{'feature': 'Lenses', 'value': 'Ultrasheen'}, {'feature': 'UV Protection', 'value': null}, {'feature': 'Frames', 'value': 'LightCompose'}]};
-
 
 class OutfitCarousel extends React.Component {
   constructor(props) {
@@ -29,7 +27,6 @@ class OutfitCarousel extends React.Component {
   componentDidUpdate() {
     console.log(this.state.yourOutfit);
     window.localStorage.setItem('relatedProducts', JSON.stringify(this.state));
-    //window.localStorage.setItem('relatedProducts', 'hi');
   }
 
   removeFromOutfit() {
@@ -49,8 +46,6 @@ class OutfitCarousel extends React.Component {
 
   addProductClickHandler(event) {
     event.preventDefault();
-    //get product data from app
-    //pass to addToOutfit as parameter
     this.addToOutfit(this.props.currentProduct);
   }
 

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -8,6 +8,7 @@ class OutfitCarousel extends React.Component {
   constructor(props) {
     super(props);
     this.removeFromOutfit = this.removeFromOutfit.bind(this);
+    this.removeProductClickHandler = this.removeProductClickHandler.bind(this);
     this.addToOutfit = this.addToOutfit.bind(this);
     this.addProductClickHandler = this.addProductClickHandler.bind(this);
 
@@ -25,15 +26,15 @@ class OutfitCarousel extends React.Component {
     }
   }
   componentDidUpdate() {
-    console.log(this.state.yourOutfit);
     window.localStorage.setItem('relatedProducts', JSON.stringify(this.state));
   }
 
-  removeFromOutfit() {
+  removeFromOutfit(product) {
+    let currentOutfit = this.state.yourOutfit;
+    delete currentOutfit[product.id];
     this.setState({
-      yourOutfit: 'bye'
+      yourOutfit: currentOutfit
     });
-    console.log('remove from Outfit');
   }
 
   addToOutfit(newProduct) {
@@ -46,7 +47,12 @@ class OutfitCarousel extends React.Component {
 
   addProductClickHandler(event) {
     event.preventDefault();
+    event.target.setAttribute('disabled', true);
     this.addToOutfit(this.props.currentProduct);
+  }
+
+  removeProductClickHandler(event, data) {
+    this.removeFromOutfit(data);
   }
 
   render() {
@@ -56,10 +62,9 @@ class OutfitCarousel extends React.Component {
           First Slide
           <button onClick={this.addProductClickHandler}>add to outfit</button>
         </FirstSlide>
-        {/* change to use this.state.yourOutfit once add button adds productData */}
-        {Object.values(this.props.data).map((product) => {
+        {Object.values(this.state.yourOutfit).map((product) => {
           return <StyledSlide data={product}
-            cardButtonClick={this.removeFromOutfit}
+            cardButtonClick={this.removeProductClickHandler}
             key={product.id}
             render={onClick => (
               <button onClick={onClick}>x</button>
@@ -82,8 +87,11 @@ const FirstSlide = styled.div`
   background-color: grey;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: space-between;
+  align-items: flex-end;
+
 `;
+
 
 
 export default OutfitCarousel;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -3,22 +3,33 @@ import PropTypes from 'prop-types';
 import StyledSlide from './Slide.jsx';
 import styled from 'styled-components';
 
+let fakeProduct = {'id': 19090, 'campus': 'hr-rfe', 'name': 'Bright Future Sunglasses', 'slogan': 'You\'ve got to wear shades', 'description': 'Where you\'re going you might not need roads, but you definitely need some shades. Give those baby blues a rest and let the future shine bright on these timeless lenses.', 'category': 'Accessories', 'default_price': '69.00', 'created_at': '2021-02-23T19:24:34.450Z', 'updated_at': '2021-02-23T19:24:34.450Z', 'features': [{'feature': 'Lenses', 'value': 'Ultrasheen'}, {'feature': 'UV Protection', 'value': null}, {'feature': 'Frames', 'value': 'LightCompose'}]};
+
 
 class OutfitCarousel extends React.Component {
   constructor(props) {
     super(props);
     this.removeFromOutfit = this.removeFromOutfit.bind(this);
     this.addToOutfit = this.addToOutfit.bind(this);
+    this.addProductClickHandler = this.addProductClickHandler.bind(this);
 
     this.state = {
-      yourOutfit: JSON.parse(
-        window.localStorage.getItem('yourOutfit')
-      ) || {}
+      yourOutfit: {}
     };
   }
 
+  componentDidMount() {
+    var localStorage = JSON.parse(window.localStorage.getItem('relatedProducts'));
+    if (localStorage && localStorage.yourOutfit) {
+      this.setState({
+        yourOutfit: localStorage.yourOutfit
+      });
+    }
+  }
   componentDidUpdate() {
-    window.localStorage.setItem('yourOutfit', JSON.stringify(this.state));
+    console.log(this.state.yourOutfit);
+    window.localStorage.setItem('relatedProducts', JSON.stringify(this.state));
+    //window.localStorage.setItem('relatedProducts', 'hi');
   }
 
   removeFromOutfit() {
@@ -28,11 +39,19 @@ class OutfitCarousel extends React.Component {
     console.log('remove from Outfit');
   }
 
-  addToOutfit() {
+  addToOutfit(newProduct) {
+    let currentOutfit = this.state.yourOutfit;
+    currentOutfit[newProduct['id']] = newProduct;
     this.setState({
-      yourOutfit: 'hi'
+      yourOutfit: currentOutfit
     });
-    console.log('add to outfit');
+  }
+
+  addProductClickHandler(event) {
+    event.preventDefault();
+    //get product data from app
+    //pass to addToOutfit as parameter
+    this.addToOutfit(fakeProduct);
   }
 
   render() {
@@ -40,8 +59,9 @@ class OutfitCarousel extends React.Component {
       <>
         <FirstSlide>
           First Slide
-          <button onClick={this.addToOutfit}>add to outfit</button>
+          <button onClick={this.addProductClickHandler}>add to outfit</button>
         </FirstSlide>
+        {/* change to use this.state.yourOutfit once add button adds productData */}
         {Object.values(this.props.data).map((product) => {
           return <StyledSlide data={product}
             cardButtonClick={this.removeFromOutfit}
@@ -68,5 +88,6 @@ const FirstSlide = styled.div`
   flex-direction: column;
   justify-content: center;
 `;
+
 
 export default OutfitCarousel;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import StyledSlide from './Slide.jsx';
+import styled from 'styled-components';
 
 
 class OutfitCarousel extends React.Component {
@@ -16,7 +17,10 @@ class OutfitCarousel extends React.Component {
   render() {
     return (
       <>
-        <div>First Slide</div>
+        <FirstSlide>
+          First Slide
+          <button onClick={() => { console.log('add to outfit'); }}>add to outfit</button>
+        </FirstSlide>
         {Object.values(this.props.data).map((product) => {
           return <StyledSlide data={product}
             cardButtonClick={this.cardButtonClick}
@@ -34,5 +38,14 @@ class OutfitCarousel extends React.Component {
 OutfitCarousel.propTypes = {
   data: PropTypes.object.isRequired
 };
+
+const FirstSlide = styled.div`
+  width: 150px;
+  height: 200px;
+  background-color: grey;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
 
 export default OutfitCarousel;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -7,11 +7,32 @@ import styled from 'styled-components';
 class OutfitCarousel extends React.Component {
   constructor(props) {
     super(props);
-    this.cardButtonClick = this.cardButtonClick.bind(this);
+    this.removeFromOutfit = this.removeFromOutfit.bind(this);
+    this.addToOutfit = this.addToOutfit.bind(this);
+
+    this.state = {
+      yourOutfit: JSON.parse(
+        window.localStorage.getItem('yourOutfit')
+      ) || {}
+    };
   }
 
-  cardButtonClick() {
-    console.log('outfit click');
+  componentDidUpdate() {
+    window.localStorage.setItem('yourOutfit', JSON.stringify(this.state));
+  }
+
+  removeFromOutfit() {
+    this.setState({
+      yourOutfit: 'bye'
+    });
+    console.log('remove from Outfit');
+  }
+
+  addToOutfit() {
+    this.setState({
+      yourOutfit: 'hi'
+    });
+    console.log('add to outfit');
   }
 
   render() {
@@ -19,11 +40,11 @@ class OutfitCarousel extends React.Component {
       <>
         <FirstSlide>
           First Slide
-          <button onClick={() => { console.log('add to outfit'); }}>add to outfit</button>
+          <button onClick={this.addToOutfit}>add to outfit</button>
         </FirstSlide>
         {Object.values(this.props.data).map((product) => {
           return <StyledSlide data={product}
-            cardButtonClick={this.cardButtonClick}
+            cardButtonClick={this.removeFromOutfit}
             key={product.id}
             render={onClick => (
               <button onClick={onClick}>x</button>

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -68,7 +68,7 @@ class RelatedProductsWrapper extends React.Component {
             return <RelatedCarousel data={data}/>;
           }}/>
         <CarouselWrapper
-          data={this.state.relatedProductsData}
+          data={{}}
           render={(data) => {
             return <OutfitCarousel data={data} />;
           }} />

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -16,9 +16,10 @@ class RelatedProductsWrapper extends React.Component {
 
   //get list of related products using productId prop
   getRelatedProducts() {
-    axios.get('/api/products/19089/related', {
+    let product_id = this.props.product_id;
+    axios.get(`/api/products/${product_id}/related`, {
       params: {
-        product_id: 19089
+        product_id: {product_id}
       }
     }).then(({data}) => {
       return Promise.all(data.map((id) => {
@@ -78,7 +79,8 @@ class RelatedProductsWrapper extends React.Component {
 }
 
 RelatedProductsWrapper.propTypes = {
-  product_id: PropTypes.number
+  product_id: PropTypes.number,
+  product: PropTypes.object
 };
 
 export default RelatedProductsWrapper;

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -71,7 +71,7 @@ class RelatedProductsWrapper extends React.Component {
         <CarouselWrapper
           data={{}}
           render={(data) => {
-            return <OutfitCarousel data={data} />;
+            return <OutfitCarousel currentProduct={this.props.product} data={data} />;
           }} />
       </div>
     );

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -11,7 +11,7 @@ class Slide extends Component {
 
   handleButtonClick(event) {
     event.preventDefault();
-    this.props.cardButtonClick();
+    this.props.cardButtonClick(event, this.props.data);
   }
 
   render() {


### PR DESCRIPTION
This corresponds to [this ticket](https://trello.com/c/AZGsDiPa) and [this ticket](https://trello.com/c/AZGsDiPa)
- Adds padding to carousels so they aren't stuck together
- Stores a users current outfit in local storage under the relatedProducts key
- Clicking the 'add to outfit' button adds the product that's currently in the overview to the user's outfit
- Removes dummy data from 'your outfit' carousel to reflect a default empty outfit