### PR TITLE
Fix scroll buttons visibility bug

### DIFF
--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -7,6 +7,7 @@ class CarouselWrapper extends React.Component {
     super(props);
     this.scrollRight = this.scrollRight.bind(this);
     this.scrollLeft = this.scrollLeft.bind(this);
+    this.checkScroll = this.checkScroll.bind(this);
     this.state = {
       showLeftScroll: false,
       showRightScroll: true,
@@ -55,18 +56,24 @@ class CarouselWrapper extends React.Component {
   }
 
   componentDidMount() {
-    if (this.ref.current && this.ref.current.children.length < 4) {
+    if (this.ref.current.children.length < 4) {
       this.setState({
         showLeftScroll: false,
         showRightScroll: false
       });
     }
-
+    console.log(this.ref.current.attributes.id, this.ref.current.children.length);
+    console.log(this.ref.current.attributes.id, this.ref.current.clientWidth);
+    console.log(this.ref.current.attributes.id, this.ref.current.scrollWidth);
   }
 
   render() {
+    if (this.ref.current) {
+      console.log(this.ref.current.attributes.id, 'children', this.ref.current.children.length);
+    }
     return (
-      <StyledCarouselWrapper>
+      <StyledCarouselWrapper
+        onMouseEnter={this.checkScroll}>
         <LeftCarouselButton show={this.state.showLeftScroll}
           onClick={this.scrollLeft}>{'<'}</LeftCarouselButton>
         <CarouselContainer

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -55,13 +55,13 @@ class CarouselWrapper extends React.Component {
   }
 
   componentDidMount() {
-    if (this.ref.current && this.ref.current.children.length < 5) {
+    if (this.ref.current && this.ref.current.children.length < 4) {
       this.setState({
         showLeftScroll: false,
         showRightScroll: false
       });
     }
-    console.log(this.ref);
+
   }
 
   render() {
@@ -97,7 +97,6 @@ const StyledCarouselWrapper = styled.div`
   width: 80%;
 `;
 const CarouselContainer = styled.div`
-  width: 100%;
   display: flex;
   flex-wrap: nowrap;
   overflow-x: hidden;
@@ -111,7 +110,6 @@ const CarouselContainer = styled.div`
 
 const CarouselButton = styled.button`
   display: ${props => props.show ? 'block' : 'none'};
-  position: absolute;
   cursor: pointer;
   top: 50%;
   z-index: 1;

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -8,73 +8,70 @@ class CarouselWrapper extends React.Component {
     this.scrollRight = this.scrollRight.bind(this);
     this.scrollLeft = this.scrollLeft.bind(this);
     this.state = {
-      showLeftScroll: true,
+      showLeftScroll: false,
       showRightScroll: true,
       scrollWidth: 0
     };
+
+    this.ref = React.createRef();
+  }
+
+  checkScroll() {
+    if (this.ref.current.scrollWidth <= this.ref.current.clientWidth) {
+      this.setState({
+        showLeftScroll: false,
+        showRightScroll: false,
+      });
+      return;
+    }
+    if (this.ref.current.scrollLeft === 0) {
+      this.setState({
+        showLeftScroll: false,
+        showRightScroll: true
+      });
+      return;
+    }
+    if (this.ref.current.scrollLeft + this.ref.current.clientWidth >= this.ref.current.scrollWidth) {
+      this.setState({
+        showRightScroll: false,
+        showLeftScroll: true,
+      });
+      return;
+    }
+    this.setState({
+      showRightScroll: true,
+      showLeftScroll: true,
+    });
   }
 
   scrollRight() {
-    this.container.scrollLeft += 200;
-    if (this.container.scrollWidth <= this.container.clientWidth) {
-      this.setState({
-        showLeftScroll: false,
-        showRightScroll: false,
-      });
-      return;
-    }
-    if (this.container.scrollLeft + this.container.clientWidth >= this.container.scrollWidth) {
-      this.setState({
-        showRightScroll: false,
-        showLeftScroll: true,
-      });
-    } else {
-      this.setState({
-        showLeftScroll: true,
-      });
-    }
+    this.ref.current.scrollLeft += this.ref.current.firstChild.clientWidth;
+    this.checkScroll();
   }
 
   scrollLeft() {
-    this.container.scrollLeft -= 200;
-    if (this.container.scrollWidth <= this.container.clientWidth) {
-      this.setState({
-        showLeftScroll: false,
-        showRightScroll: false,
-      });
-      return;
-    }
-    if (this.container.scrollLeft === 0) {
-      this.setState({
-        showRightScroll: true,
-        showLeftScroll: false
-      });
-    } else {
-      this.setState({
-        showRightScroll: true,
-      });
-    }
+    this.ref.current.scrollLeft -= this.ref.current.firstChild.clientWidth;
+    this.checkScroll();
   }
 
   componentDidMount() {
-    this.container = document.getElementById(this.props.name + 'Container');
-    if (this.props.name === 'yourOutfit') {
+    if (this.ref.current && this.ref.current.children.length < 5) {
       this.setState({
-        showLeftScroll: false
+        showLeftScroll: false,
+        showRightScroll: false
       });
-      return;
     }
+    console.log(this.ref);
   }
 
   render() {
-    if (document.getElementById(this.props.name + 'Container')) {
-      this.container = document.getElementById(this.props.name + 'Container');
-    }
     return (
       <StyledCarouselWrapper>
         <LeftCarouselButton show={this.state.showLeftScroll}
           onClick={this.scrollLeft}>{'<'}</LeftCarouselButton>
-        <CarouselContainer id={this.props.name + 'Container'}>
+        <CarouselContainer
+          id={this.props.name + 'Container'}
+          ref={this.ref}>
           {this.props.render(this.props.data)}
         </CarouselContainer>
         <RightCarouselButton show={this.state.showRightScroll}
@@ -97,7 +94,7 @@ const StyledCarouselWrapper = styled.div`
   align-items: center;
   margin-top: 4em;
   position: relative;
-
+  width: 80%;
 `;
 const CarouselContainer = styled.div`
   width: 100%;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -29,6 +29,10 @@ class OutfitCarousel extends React.Component {
     window.localStorage.setItem('relatedProducts', JSON.stringify(this.state));
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return this.state.yourOutfit !== nextState.yourOutfit;
+  }
+
   removeFromOutfit(product) {
     let currentOutfit = this.state.yourOutfit;
     delete currentOutfit[product.id];

--- a/client/src/relatedProducts/RelatedCarousel.jsx
+++ b/client/src/relatedProducts/RelatedCarousel.jsx
@@ -34,6 +34,10 @@ class RelatedCarousel extends React.Component {
     this.showModal(data);
   }
 
+  shouldComponentUpdate(nextProps) {
+    return this.state.isLoading || !(this.props.data === nextProps.data);
+  }
+
   render() {
     return (
       <>

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -55,12 +55,14 @@ class RelatedProductsWrapper extends React.Component {
     this.getRelatedProducts();
   }
 
+  shouldComponentUpdate(nextProps) {
+    return this.state.isLoading || !(this.props.product_id === nextProps.product_id);
+  }
 
   render() {
     if (this.state.isLoading) {
       return <div>RELATED LOADING</div>;
     }
-
     return (
       <div>
         <ModuleHeader>Related Products</ModuleHeader>


### PR DESCRIPTION
This PR fixes the bug where scroll buttons appeared even where there's nowhere to scroll.
It also fixes the issue where carousels took more more page width than they needed. 
Finally, it stops child components (slides) from updating on every scroll button click to reduce the number of API requests for the same information.