### PR TITLE
Modal accessibility

### DIFF
--- a/client/src/ModalImage.jsx
+++ b/client/src/ModalImage.jsx
@@ -9,10 +9,18 @@ class ModalImage extends React.Component {
     this.state = {
       active: false
     };
+
+    this.ref = React.createRef();
   }
 
   displayModal() {
     this.setState({active: !this.state.active});
+  }
+
+  componentDidUpdate() {
+    if (this.state.active) {
+      this.ref.current.focus();
+    }
   }
 
   render() {
@@ -27,7 +35,8 @@ class ModalImage extends React.Component {
     return (
       <ModalWindow onClick={this.displayModal.bind(this)}>
         <ImageWrapper>
-          <PositionedButton>X</PositionedButton>
+          <PositionedButton
+            ref={this.ref}>X</PositionedButton>
           <FullImage
             src={this.props.src}
           />

--- a/client/src/relatedProducts/Modal.jsx
+++ b/client/src/relatedProducts/Modal.jsx
@@ -34,41 +34,51 @@ let compareFeatures = (data, currentProduct) => {
   return Object.values(combinedFeatures);
 };
 
-const Modal = (props) => {
+const Modal = React.forwardRef((props, ref) => {
+
+
   const { handleClose, data, currentProduct } = props;
-  if (!props.show) {
-    return <div></div>;
+  let table = <div></div>;
+  if (props.show) {
+    table = (<Table>
+      <TableBody>
+        {
+          compareFeatures(data, currentProduct).map((row) => {
+            let { currentValue, featureName, clickedValue } = row;
+            //If the product's value is true, display a checkmark
+            currentValue = currentValue === 'true' ? '✓' : currentValue;
+            clickedValue = clickedValue === 'true' ? '✓' : clickedValue;
+            return (<Row key={featureName}>
+              <Field width='10%'>{currentValue}</Field>
+              <Field width='80%'>{featureName}</Field>
+              <Field width='10%'>{clickedValue}</Field>
+            </Row>);
+          })
+        }
+      </TableBody>
+    </Table>);
   }
+
   return (
     <div className={props.className}>
       <ModalTable>
-        <CloseButton type="button" onClick={handleClose}>x</CloseButton>
+        <CloseButton
+          ref={ref}
+          type="button"
+          onClick={handleClose}>x</CloseButton>
         <LowPriorityText>Comparing</LowPriorityText>
         <HeaderRow>
           <p>{currentProduct.name}</p>
           <p>{data.name}</p>
         </HeaderRow>
-        <Table>
-          <TableBody>
-            {
-              compareFeatures(data, currentProduct).map((row) => {
-                let {currentValue, featureName, clickedValue} = row;
-                //If the product's value is true, display a checkmark
-                currentValue = currentValue === 'true' ? '✓' : currentValue;
-                clickedValue = clickedValue === 'true' ? '✓' : clickedValue;
-                return (<Row key={featureName}>
-                  <Field width='10%'>{currentValue}</Field>
-                  <Field width='80%'>{featureName}</Field>
-                  <Field width='10%'>{clickedValue}</Field>
-                </Row>);
-              })
-            }
-          </TableBody>
-        </Table>
+        {table}
       </ModalTable>
     </div>
   );
-};
+});
+
+
+Modal.displayName = 'Modal';
 
 Modal.propTypes = {
   className: PropTypes.string.isRequired,
@@ -152,8 +162,9 @@ const CloseButton = styled(Button)`
   z-index: 1;
   padding: 0 0.75rem;
   height: 2rem;
+  tab-index: 1;
 `;
 
 
 
-export {StyledModal as default, compareFeatures};
+export { StyledModal as default, compareFeatures };

--- a/client/src/relatedProducts/RelatedCarousel.jsx
+++ b/client/src/relatedProducts/RelatedCarousel.jsx
@@ -15,6 +15,8 @@ class RelatedCarousel extends React.Component {
     this.showModal = this.showModal.bind(this);
     this.hideModal = this.hideModal.bind(this);
     this.cardButtonClick = this.cardButtonClick.bind(this);
+
+    this.modalRef = React.createRef();
   }
 
   showModal(data) {
@@ -37,6 +39,11 @@ class RelatedCarousel extends React.Component {
   shouldComponentUpdate(nextProps, nextState) {
     return !(this.props.data === nextProps.data) || (this.state.showModal !== nextState.showModal);
   }
+  componentDidUpdate() {
+    if (this.state.showModal) {
+      this.modalRef.current.focus();
+    }
+  }
 
   render() {
     return (
@@ -57,6 +64,7 @@ class RelatedCarousel extends React.Component {
 
 
         <StyledModal
+          ref={this.modalRef}
           id='related-products-modal'
           show={this.state.showModal}
           handleClose={this.hideModal}


### PR DESCRIPTION
This PR corresponds with [this ticket](https://trello.com/c/a5fLkesT)
It shifts focus to modal window close buttons when they pop up.

Note: This change only affects comparison modals for related products and thumbnail modals.
