### PR TITLE
Bug Fix: state update on an unmounted component

### DIFF
--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -26,6 +26,7 @@ class Slide extends Component {
         if (response && response.data) {
           return response.data;
         }
+      }).catch(() => {
         throw Error('fetching styles data failed');
       });
   }
@@ -37,6 +38,7 @@ class Slide extends Component {
         if (response && response.data) {
           return response.data;
         }
+      }).catch(() => {
         throw Error('fetching review meta data failed');
       });
   }
@@ -60,7 +62,7 @@ class Slide extends Component {
         });
       })
       .catch((error) => {
-        console.error('Overview Error:', error);
+        console.error('Slide Error:', error);
       });
     this.fetchReviewMetaDataFromApi()
       .then((data) => {

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -87,6 +87,13 @@ class Slide extends Component {
       });
   }
 
+  componentWillUnmount() {
+    // fix Warning: Can't perform a React state update on an unmounted component
+    this.setState = () => {
+      return;
+    };
+  }
+
   render() {
     if (this.state.loading) {
       return <div></div>;


### PR DESCRIPTION
This PR corresponds with [this ticket](https://trello.com/c/oyzHgykz)
It fixes a bug where the Slide component was attempting to set its state once unmounted. This happened when the user clicked quickly between product cards, since the component was making API calls for thumbnails and style data.
It also adds catch blocks to API calls to handle future errors with a little more grace.
