### PR TITLE
add support for inline source maps during development

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -2,5 +2,6 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
-  mode: 'development'
+  mode: 'development',
+  devtool: 'inline-source-map'
 });


### PR DESCRIPTION
Adding a line in the webpack development config file to support inline source maps. This may help with debugging, and there is only one yellow warning in the console now on initial page load instead of 4.