### PR TITLE
Fixed import issue with propTypes

### DIFF
--- a/client/src/overview/ProductFeatures.jsx
+++ b/client/src/overview/ProductFeatures.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import ProductType from './types';
 import { Tile } from '../globalStyles';
 import styled from 'styled-components';
+import { ProductType } from './types.js';
+
 
 const PaddedTile = styled(Tile)`
   padding: 2rem;


### PR DESCRIPTION
This PR corresponds with [this ticket](https://trello.com/c/PA81TTcR)
It fixes an issue when importing predefined propTypes shapes that was throwing an error in the console on page load.
Screenshot of issue:
<img width="1129" alt="Screen Shot 2021-03-12 at 11 20 06 AM" src="https://user-images.githubusercontent.com/38890546/110970274-94e60d80-8327-11eb-9070-9bf45ef94c66.png">
