### PR TITLE
Enable Https if Certificates Present

### DIFF
--- a/server/config.example.js
+++ b/server/config.example.js
@@ -3,5 +3,10 @@ module.exports = {
   // Github API Permission requirements:
   // User - all
   // Admin - read:org
-  token: 'YOUR_TOKEN_HERE'
+  token: 'YOUR_TOKEN_HERE',
+  // Letsencrypt certificate
+  certificateKey: '/path/to/privkey.pem',
+  certificateChain: '/path/to/fullchain.pem',
+  httpPort: 3000,
+  httpsPort: 3001
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,18 @@
-const app = require('./app.js')
+const app = require('./app.js');
 const port = 3000;
+const fs = require('fs');
+const https = require('https');
+
+// Certificate
+const privateKey = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/privkey.pem', 'utf8');
+// const certificate = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/cert.pem', 'utf8');
+const ca = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/chain.pem', 'utf8');
 
 app.listen(port, () => {
   console.log(`Atelier client is listening on ${port}`);
 });
+
+https.createServer({
+  key: privateKey,
+  cert: ca
+}, app).listen(port);

--- a/server/index.js
+++ b/server/index.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const https = require('https');
 
 // Certificate
-const privateKey = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/privkey.pem', 'utf8');
+const privateKey = fs.readFileSync('/home/ubuntu/privkey.pem', 'utf8');
 // const certificate = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/cert.pem', 'utf8');
-const ca = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/chain.pem', 'utf8');
+const ca = fs.readFileSync('/home/ubuntu/chain.pem', 'utf8');
 
 app.listen(port, () => {
   console.log(`Atelier client is listening on ${port}`);

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,7 @@ const privateKey = fs.readFileSync('/home/ubuntu/privkey.pem', 'utf8');
 // const certificate = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/cert.pem', 'utf8');
 const ca = fs.readFileSync('/home/ubuntu/chain.pem', 'utf8');
 
-app.listen(port, () => {
+app.listen(8080, () => {
   console.log(`Atelier client is listening on ${port}`);
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,18 +1,55 @@
 const app = require('./app.js');
-const port = 3000;
 const fs = require('fs');
 const https = require('https');
+const config = require('./config');
 
-// Certificate
-const privateKey = fs.readFileSync('/home/ubuntu/privkey.pem', 'utf8');
-// const certificate = fs.readFileSync('/etc/letsencrypt/live/zaphcast.com/cert.pem', 'utf8');
-const ca = fs.readFileSync('/home/ubuntu/chain.pem', 'utf8');
+// set default config values
+const defaultConfig = {
+  certificateKey: '',
+  certificateChain: '',
+  httpPort: 3000,
+  httpsPort: 3001
+};
 
-app.listen(8080, () => {
-  console.log(`Atelier client is listening on ${port}`);
+// no default for Github API token - throw error if not present
+// we want to fail early and loud if not present
+if (!config.token) {
+  console.error('No Github API token present in config.js!');
+  throw Error('Missing Github token');
+}
+
+// make changes non breaking if config hasn't been updated
+let keys = Object.keys(defaultConfig);
+keys.forEach((key) => {
+  if (!config[key]) {
+    console.log(`key "${key}" missing from config file; using default: ${defaultConfig[key] === '' ? 'empty string' : `"${defaultConfig[key]}"` }`);
+  }
 });
 
-https.createServer({
-  key: privateKey,
-  cert: ca
-}, app).listen(port);
+
+const certificateKey = config['certificateKey'] || defaultConfig['certificateKey'];
+const certificateChain = config['certificateChain'] || defaultConfig['certificateChain'];
+const httpPort = config['httpPort'] || defaultConfig['httpPort'];
+const httpsPort = config['httpsPort'] || defaultConfig['httpsPort'];
+
+
+app.listen(httpPort, () => {
+  console.log(`HTTP client: ACTIVE on port ${httpPort}`);
+});
+
+//
+try {
+  // to run https we need to load the certificate data
+  // if it is not present or inaccessible it will throw an error
+  const privateKey = fs.readFileSync(certificateKey, 'utf8');
+  const ca = fs.readFileSync(certificateChain, 'utf8');
+  // create https server if no error has occurred
+  https.createServer({
+    key: privateKey,
+    cert: ca
+  }, app).listen(httpsPort, () => {
+    console.log(`HTTP client: ACTIVE on port ${httpsPort}`);
+  });
+} catch (error) {
+  console.log(`HTTPS client: NOT ACTIVE on port ${httpsPort}`);
+}


### PR DESCRIPTION
This references [ticket #222](https://trello.com/c/I4gKuBg0/222-enable-deployment-with-https)

- Config file now holds path to SSL certificates and port numbers to use for http and https
- If valid SSL certs are found at the path specified in config, an htttps server will be set up
- index.js supplies default values for new additions to config file so that changes are non-breaking
- console message appears to warn that a default value has been used
- app throws error if no github token is present in config file