### PR TITLE
Styling/Code readability

### DIFF
--- a/client/src/globalStyles.js
+++ b/client/src/globalStyles.js
@@ -58,6 +58,10 @@ const TilePreset = styled.div`
   border: 1px solid ${({ theme }) => theme.borders};
 `;
 
+const TileWithLabelPreset = styled(TilePreset)`
+  margin-left: 3rem;
+`;
+
 //NOTE: font not finalized, we may wish to use an alt to Garamont so using <Italic> rather than manually setting font-style may save you future reworking
 const ItalicPreset = styled.span`
   font-style: italic;
@@ -168,7 +172,7 @@ const LabelPreset = styled.div`
   position: absolute;
   bottom: 0;
   left: 0;
-  margin-left: -30px;
+  margin-left: -3rem;
   background-color: ${props => props.theme.primary};
 
   h3 {
@@ -178,13 +182,14 @@ const LabelPreset = styled.div`
     bottom: 0;
     position: absolute;
     left: 0;
-    width: 350px;
-    margin-left: 4px;
+    width: 35rem;
+    margin-left: 0.5rem;
   }
 `;
 
 export const GlobalStyle = GlobalPreset;
 export const Tile = TilePreset;
+export const TileWithLabel = TileWithLabelPreset;
 export const ClickableText = ClickableTextPreset;
 export const LowPriorityText = LowPriorityTextPreset;
 export const Button = ButtonPreset;

--- a/client/src/ratingsAndReviews/ReviewsList.jsx
+++ b/client/src/ratingsAndReviews/ReviewsList.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Tile, Button, Label, Italic } from '../globalStyles.js';
+import { Button, Label, Italic, TileWithLabel } from '../globalStyles.js';
 import IndividualReview from './IndividualReview.jsx';
 import Ratings from './Ratings.jsx';
 import FactorsBreakdown from './FactorsBreakdown.jsx';
@@ -181,7 +181,7 @@ const RatingsReviewsPanel = styled.div`
   display: flex;
 `;
 
-const SharpTile = styled(Tile)`
+const SharpTile = styled(TileWithLabel)`
   border-radius: 0;
 `;
 

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -100,6 +100,7 @@ const StyledCarouselWrapper = styled(TileWithLabel)`
   align-items: center;
   margin-top: 4em;
   position: relative;
+  border: none;
 `;
 const CarouselContainer = styled.div`
   border-radius: 0px;

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -100,7 +100,6 @@ const StyledCarouselWrapper = styled(TileWithLabel)`
   align-items: center;
   margin-top: 4em;
   position: relative;
-  width: fit-content;
 `;
 const CarouselContainer = styled.div`
   border-radius: 0px;

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -100,6 +100,7 @@ const StyledCarouselWrapper = styled(TileWithLabel)`
   align-items: center;
   margin-top: 4em;
   position: relative;
+  width: fit-content;
 `;
 const CarouselContainer = styled.div`
   border-radius: 0px;

--- a/client/src/relatedProducts/CarouselWrapper.jsx
+++ b/client/src/relatedProducts/CarouselWrapper.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
+import { TileWithLabel, Label } from '../globalStyles';
 
 class CarouselWrapper extends React.Component {
   constructor(props) {
@@ -92,29 +93,7 @@ CarouselWrapper.propTypes = {
   render: PropTypes.func.isRequired,
 };
 
-const Label = styled.div`
-  width: 15rem;
-  height: 100%;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  margin-left: -30px;
-  background-color: ${props => props.theme.primary};
-
-  h3 {
-    color: ${props => props.theme.topLayer};
-    transform-origin: 0 0;
-    transform: rotate(270deg);
-    bottom: 0;
-    position: absolute;
-    left: 0;
-    width: 350px;
-    margin-left: 4px;
-  }
-`;
-
-
-const StyledCarouselWrapper = styled.div`
+const StyledCarouselWrapper = styled(TileWithLabel)`
   border-radius: 0px;
   display: flex;
   flex-direction: row;

--- a/client/src/relatedProducts/Modal.jsx
+++ b/client/src/relatedProducts/Modal.jsx
@@ -162,7 +162,7 @@ const StyledModal = styled(Modal)`
 
 const CloseButton = styled(Button)`
   position: sticky;
-  top: 5%;
+  top: 2%;
   left: 90%;
   z-index: 1;
   padding: 0 0.75rem;

--- a/client/src/relatedProducts/Modal.jsx
+++ b/client/src/relatedProducts/Modal.jsx
@@ -66,10 +66,12 @@ const Modal = React.forwardRef((props, ref) => {
           ref={ref}
           type="button"
           onClick={handleClose}>x</CloseButton>
-        <LowPriorityText>Comparing</LowPriorityText>
         <HeaderRow>
-          <p>{currentProduct.name}</p>
-          <p>{data.name}</p>
+          <LowPriorityText>Comparing</LowPriorityText>
+          <div>
+            <p>{currentProduct.name}</p>
+            <p>{data.name}</p>
+          </div>
         </HeaderRow>
         {table}
       </ModalTable>
@@ -93,15 +95,18 @@ const Row = styled.tr`
 `;
 
 const HeaderRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: 0.25em;
+  padding-bottom: 0.25em;
   position: sticky;
-  top: 2.5em;
+  top: 0em;
   background: ${props => props.theme.midLight};
+  margin-top: 1rem;
 
-  p {
+  div {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  div > p {
     font-weight: bold;
     padding: 0.5em;
     margin: 0;

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -13,19 +13,22 @@ class OutfitCarousel extends React.Component {
     this.addProductClickHandler = this.addProductClickHandler.bind(this);
 
     this.state = {
-      yourOutfit: {}
+      outfit: {}
     };
   }
 
   componentDidMount() {
+    //set state to user's outfit data from local storage if present
     var localStorage = JSON.parse(window.localStorage.getItem('relatedProducts'));
     if (localStorage && localStorage.yourOutfit) {
       this.setState({
-        yourOutfit: localStorage.yourOutfit
+        outfit: localStorage.yourOutfit
       });
     }
   }
+
   componentDidUpdate() {
+    //update local storage to reflect changed outfit
     window.localStorage.setItem('relatedProducts', JSON.stringify(this.state));
   }
 
@@ -34,23 +37,24 @@ class OutfitCarousel extends React.Component {
   }
 
   removeFromOutfit(product) {
-    let currentOutfit = this.state.yourOutfit;
+    let currentOutfit = this.state.outfit;
     delete currentOutfit[product.id];
     this.setState({
-      yourOutfit: currentOutfit
+      outfit: currentOutfit
     });
   }
 
   addToOutfit(newProduct) {
-    let currentOutfit = this.state.yourOutfit;
+    let currentOutfit = this.state.outfit;
     currentOutfit[newProduct['id']] = newProduct;
     this.setState({
-      yourOutfit: currentOutfit
+      outfit: currentOutfit
     });
   }
 
   addProductClickHandler(event) {
     event.preventDefault();
+    //current product can only be added once
     event.target.setAttribute('disabled', true);
     this.addToOutfit(this.props.currentProduct);
   }
@@ -65,7 +69,7 @@ class OutfitCarousel extends React.Component {
         <FirstSlide onClick={this.addProductClickHandler}>
           <p>Add Product to Outfit</p>
         </FirstSlide>
-        {Object.values(this.state.yourOutfit).map((product) => {
+        {Object.values(this.state.outfit).map((product) => {
           return <StyledSlide data={product}
             cardButtonClick={this.removeProductClickHandler}
             key={product.id}

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -20,7 +20,6 @@ class OutfitCarousel extends React.Component {
   componentDidMount() {
     //set state to user's outfit data from local storage if present
     var localStorage = JSON.parse(window.localStorage.getItem('relatedProducts'));
-    console.log(localStorage);
     if (localStorage && localStorage.outfit) {
       this.setState({
         outfit: localStorage.outfit

--- a/client/src/relatedProducts/OutfitCarousel.jsx
+++ b/client/src/relatedProducts/OutfitCarousel.jsx
@@ -20,9 +20,10 @@ class OutfitCarousel extends React.Component {
   componentDidMount() {
     //set state to user's outfit data from local storage if present
     var localStorage = JSON.parse(window.localStorage.getItem('relatedProducts'));
-    if (localStorage && localStorage.yourOutfit) {
+    console.log(localStorage);
+    if (localStorage && localStorage.outfit) {
       this.setState({
-        outfit: localStorage.yourOutfit
+        outfit: localStorage.outfit
       });
     }
   }

--- a/client/src/relatedProducts/RelatedProducts.jsx
+++ b/client/src/relatedProducts/RelatedProducts.jsx
@@ -21,9 +21,9 @@ class RelatedProductsWrapper extends React.Component {
     let product_id = this.props.product_id;
     axios.get(`/api/products/${product_id}/related`, {
       params: {
-        product_id: {product_id}
+        product_id: { product_id }
       }
-    }).then(({data}) => {
+    }).then(({ data }) => {
       return Promise.all(data.map((id) => {
         return this.getProductData(id);
       }));
@@ -44,7 +44,7 @@ class RelatedProductsWrapper extends React.Component {
       params: {
         product_id: id
       }
-    }).then(({data}) => {
+    }).then(({ data }) => {
       this.data[data.id] = data;
     });
   }
@@ -73,8 +73,8 @@ class RelatedProductsWrapper extends React.Component {
           render={(data) => {
             return <RelatedCarousel
               data={data}
-              currentProduct={this.props.product}/>;
-          }}/>
+              currentProduct={this.props.product} />;
+          }} />
         <CarouselWrapper
           name='Your Outfit'
           data={{}}

--- a/client/src/relatedProducts/Slide.jsx
+++ b/client/src/relatedProducts/Slide.jsx
@@ -98,7 +98,11 @@ class Slide extends Component {
 
   render() {
     if (this.state.loading) {
-      return <div></div>;
+      return <StyledSlide>
+        <Button onClick={this.handleButtonClick}>
+          {this.props.buttonText}
+        </Button>
+      </StyledSlide>;
     }
     let thumb = this.state.defaultStyle.photos[0].thumbnail_url;
     return (

--- a/client/src/relatedProducts/SlideInfo.jsx
+++ b/client/src/relatedProducts/SlideInfo.jsx
@@ -12,9 +12,12 @@ const SlideInfo = (props) => {
   }
   //if the item is on sale, put sale price in red and strikethrough original price
   let saleSection = <p> {props.data.default_price}</p>;
-  if (props.data.sale_price) {
-    saleSection = <SalePrice>{props.data.sale_price}</SalePrice>;
-    saleSection += <p> <s>{props.data.default_price}</s></p>;
+  if (props.defaultStyle.sale_price) {
+    saleSection = (
+      <p>
+        <SalePrice>{props.defaultStyle.sale_price}</SalePrice>
+        <s>{props.defaultStyle.original_price}</s>
+      </p>);
   }
   return (
     <div className={props.className}>
@@ -29,6 +32,7 @@ const SlideInfo = (props) => {
 SlideInfo.propTypes = {
   className: PropTypes.string.isRequired,
   data: PropTypes.object.isRequired,
+  defaultStyle: PropTypes.object,
   reviewData: PropTypes.object
 };
 

--- a/client/src/relatedProducts/SlideInfo.jsx
+++ b/client/src/relatedProducts/SlideInfo.jsx
@@ -43,7 +43,7 @@ const StyledSlideInfo = styled(SlideInfo)`
 
   p {
     color: white;
-    margin: 0;
+    margin: 0.5rem;
   }
    &:hover {
       box-shadow: 0 10px 20px rgba(0,0,0,0.19), 0 6px 6px rgba(0,0,0,0.23);


### PR DESCRIPTION
This PR..
- Aligns modules with vertical labels to the rest of the page
     (NB: @philteves I had to change a bit of your code so both our modules would line up but it doesn't alter the layout of your reviews panel) 
- Switches Related Products to using global styles presets
- Fixes weird layout in comparison modal header
- Renames outfit variable in local storage for clarity
- Adds style changes for sale prices
- Renders empty product cards rather than a loading message while waiting for API requests to fulfill 